### PR TITLE
Renamed emboss to extrude, arrays tested with Array.isArray

### DIFF
--- a/js/path.js
+++ b/js/path.js
@@ -6,7 +6,7 @@
 (function (exports) {
 
   function Path(points) {
-    if (Object.prototype.toString.call(points) === '[object Array]') {
+    if (Array.prototype.isArray.call(points)) {
       this.points = points;
     } else {
       this.points = Array.prototype.slice.call(arguments);

--- a/js/shape.js
+++ b/js/shape.js
@@ -6,7 +6,7 @@
 (function (exports) {
 
   function Shape(paths) {
-    if (Object.prototype.toString.call(paths) === '[object Array]') {
+    if (Array.prototype.isArray.call(paths)) {
       this.paths = paths;
     } else {
       this.paths = Array.prototype.slice.call(arguments);
@@ -137,7 +137,7 @@
    * Utility function to create a 3D object by raising a 2D path
    * along the z-axis
    */
-  Shape.emboss = function (path, height) {
+  Shape.extrude = function (path, height) {
     height = height || 1;
 
     var i, topPath = path.translate(0, 0, height);

--- a/test/script.js
+++ b/test/script.js
@@ -125,7 +125,7 @@ TestSuite.testScales = function () {
   }
 };
 
-TestSuite.testEmboss = function () {
+TestSuite.testExtrude = function () {
   var basePath = new Path([
     new Point(0, 0, 0),
     new Point(1, 0, 0),
@@ -134,17 +134,17 @@ TestSuite.testEmboss = function () {
     new Point(0, 1, 0)
   ]);
 
-  iso.add(Shape.emboss(basePath)
+  iso.add(Shape.extrude(basePath)
       .scale(Point.ORIGIN, 4)
       .translate(6, 6, 0));
 };
 
 TestSuite.testCircle = function () {
-  iso.add(Shape.emboss(Path.Circle(new Point(8, 8, 0), 8)));
+  iso.add(Shape.extrude(Path.Circle(new Point(8, 8, 0), 8)));
 };
 
 TestSuite.testStar = function () {
-  iso.add(Shape.emboss(Path.Star(Point.ORIGIN, 1, 2, 4).rotateZ(Point.ORIGIN, Math.PI/6)));
+  iso.add(Shape.extrude(Path.Star(Point.ORIGIN, 1, 2, 4).rotateZ(Point.ORIGIN, Math.PI/6)));
 };
 
 


### PR DESCRIPTION
Most graphical applications, such as Maya and 3D Studio Max use the term "extrude" instead of "emboss".
Instead of using toString to test if an object type is an array, use the Array class's isArray function to perform the test.
