### PR TITLE
Proper filename for 'gulp concat' build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,7 @@ gulp.task('build', function () {
 /* Task for testing purposes - concat without minifying */
 gulp.task('concat', function () {
   gulp.src(['./js/isomer.js', './js/!(isomer)*.js'])
-    .pipe(concat('isomer.min.js'))
+    .pipe(concat('isomer.js'))
     .pipe(gulp.dest('./build'));
 });
 


### PR DESCRIPTION
Given the fact that the build for the 'gulp concat' task is not minified i think it's better to name it 'isomer.js' instead of 'isomer.min.js'.
