### PR TITLE
Add support for Node.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var concat = require('gulp-concat');
 var uglify = require('gulp-uglify');
+var insert = require('gulp-insert');
 
 /* Main gulp task to minify and concat assets */
 gulp.task('build', function () {
@@ -14,6 +15,13 @@ gulp.task('build', function () {
 gulp.task('concat', function () {
   gulp.src(['./js/isomer.js', './js/!(isomer)*.js'])
     .pipe(concat('isomer.js'))
+    .pipe(gulp.dest('./build'));
+});
+
+gulp.task('node', function () {
+  gulp.src(['./js/isomer.js', './js/!(isomer)*.js'])
+    .pipe(concat('isomer.js'))
+    .pipe(insert.append('\nmodule.exports = Isomer;'))
     .pipe(gulp.dest('./build'));
 });
 

--- a/package.json
+++ b/package.json
@@ -15,11 +15,16 @@
     "canvas",
     "3D"
   ],
+  "main": "build/isomer.js",
+  "scripts": {
+    "postinstall": "./node_modules/.bin/gulp node"
+  },
   "author": "Jordan Scales <scalesjordan@gmail.com>",
   "license": "MIT",
   "devDependencies": {
     "gulp-concat": "~2.2.0",
     "gulp": "~3.6.0",
-    "gulp-uglify": "~0.2.1"
+    "gulp-uglify": "~0.2.1",
+    "gulp-insert": "^0.3.0"
   }
 }


### PR DESCRIPTION
Hello, I like Max Ogden's workflow for frontend development with browserify and beefy:
https://gist.github.com/maxogden/5147486

That way you can throw this into a file called index.js:

``` javascript
window.Isomer = require('isomer');
```

Then, on the command-line, you can run:

```
beefy index.js:bundle.js --live
```

You can also omit the window and dev without globals, and you have a working livereload and it's really easy to just start developing right away. :smile: 

So... That's why I made this simple way to use gulp to compile something that module.exports Isomer. It's super handy! And maybe it might help with issue #16.
