### PR TITLE
precalculated transform values

### DIFF
--- a/js/isomer.js
+++ b/js/isomer.js
@@ -54,7 +54,7 @@ Isomer.prototype._translatePoint = function (point) {
    * Y rides perpendicular to this angle (in isometric view: PI - angle)
    * Z affects the y coordinate of the drawn point
    */
-  var xMap = new Point(point.x * this.transformation[0][0]
+  var xMap = new Point(point.x * this.transformation[0][0],
                        point.x * this.transformation[0][1]);
 
   var yMap = new Point(point.y * this.transformation[1][0],


### PR DESCRIPTION
Added a method to pre calculate transformation values. Previously 4 calls to trig functions were being called per point transformed. Even if scale and angle were to change per frame (currently it seems that they cant), it would be better to calculate these parameters at the beginning of the frame. Should be a minimal change that will increase performance.
