### PR TITLE
Minor fixes for animation in test suite

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -238,12 +238,14 @@ TestSuite['test rotation'] = function() {
     button.onclick = (function (fn) {
       return function () {
         /* Clear the canvas, animation callback and execute the test function */
-        iso.canvas.clear();
         clearInterval(animationTimer);
+        iso.canvas.clear();
         var f = fn();
 
         // If the test function returns a function, animate this
-        animationTimer = setInterval(f, 1000/30);
+        if (Object.prototype.toString.call(f) == '[object Function]') {
+          animationTimer = setInterval(f, 1000/30);
+        }
       };
     })(TestSuite[fn]);
 


### PR DESCRIPTION
Fixes for a couple of minor things I missed when adding animation to the test suite:
- Stop the animation timer _before_ clearing the canvas
- Only attempt to run the returned function if it's actually a function!
