### PR TITLE
Add a check for the zero vector in `Vector.normalize()`

### DIFF
--- a/js/vector.js
+++ b/js/vector.js
@@ -29,6 +29,12 @@ Vector.prototype.magnitude = function () {
 
 Vector.prototype.normalize = function () {
   var magnitude = this.magnitude();
+  /**
+   * If the magnitude is 0 then return the zero vector instead of dividing by 0
+   */
+  if (magnitude === 0) {
+    return new Vector(0, 0, 0);
+  }
   return new Vector(this.i / magnitude, this.j / magnitude, this.k / magnitude);
 };
 


### PR DESCRIPTION
This fixes coloring of lines!

In `Isomer.prototype_addPath` we find the normal of the path
and use it to determine the color. However, the normal of a
*line* returns the zero vector because math, and we probably
want to check for the zero vector when dividing by the
magnitude in `Vector.normalize()`.