### PR TITLE
Made offsets default to 0 in Point.translate

### DIFF
--- a/js/point.js
+++ b/js/point.js
@@ -16,6 +16,11 @@ Point.ORIGIN = new Point(0, 0, 0);
  * Translate a point from a given dx, dy, and dz
  */
 Point.prototype.translate = function(dx, dy, dz) {
+
+  dx = (typeof dx === 'number') ? dx : 0;
+  dy = (typeof dy === 'number') ? dy : 0;
+  dz = (typeof dz === 'number') ? dz : 0;
+
   return new Point(
     this.x + dx,
     this.y + dy,


### PR DESCRIPTION
When I tried rotating a `Shape.Pyramid`, I noticed that 2 of the (normally hidden) faces were missing. Digging into it deeper, I found out that `Point.translate` does not use 0 as the default offset, which results in an invalid Point being used to rotate the 2 front-facing triangles.

Problem could also be fixed by explicitly setting `dz` to `0` in [Line 204](https://github.com/jdan/isomer/blob/master/js/shape.js#L204) and [Line 213](https://github.com/jdan/isomer/blob/master/js/shape.js#L213) of `shape.js`, but I think it would make more sense to be able to omit the z-axis.